### PR TITLE
required vs optional action parameter support

### DIFF
--- a/src/Job.php
+++ b/src/Job.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Chevere\Workflow;
 
 use ArgumentCountError;
-use BadMethodCallException;
 use Chevere\Action\Interfaces\ActionInterface;
 use Chevere\DataStructure\Interfaces\VectorInterface;
 use Chevere\DataStructure\Vector;
@@ -148,7 +147,7 @@ final class Job implements JobInterface
             }
         }
         if ($missing !== []) {
-            throw new BadMethodCallException(
+            throw new ArgumentCountError(
                 (string) message(
                     'Missing argument(s) [`%arguments%`] for `%action%`',
                     arguments: implode(', ', $missing),
@@ -173,7 +172,7 @@ final class Job implements JobInterface
 
         $missing = array_filter(
             array_diff($requiredKeys, $intersectKeys),
-            fn(string $key) => $this->parameters->requiredKeys()->contains($key)
+            fn (string $key) => $this->parameters->requiredKeys()->contains($key)
         );
 
         array_walk($missing, function (&$item) {
@@ -183,7 +182,7 @@ final class Job implements JobInterface
         });
 
         if ($missing !== []) {
-            throw new BadMethodCallException(
+            throw new ArgumentCountError(
                 (string) message(
                     'Missing argument(s) [`%arguments%`] for `%action%`',
                     arguments: implode(', ', $missing),

--- a/src/Job.php
+++ b/src/Job.php
@@ -165,11 +165,38 @@ final class Job implements JobInterface
     private function assertArgumentsCount(array $arguments): void
     {
         $countProvided = count($arguments);
-        $countRequired = count($this->parameters->requiredKeys());
+        $requiredKeys = array_values($this->parameters->requiredKeys()->toArray());
+        $intersectKeys = array_intersect(array_keys($arguments), $requiredKeys);
+        $countRequired = count($requiredKeys);
+        $countIntersect = count($intersectKeys);
+        $countTotal = count($this->parameters->keys());
+
+        $missing = array_filter(
+            array_diff($requiredKeys, $intersectKeys),
+            fn(string $key) => $this->parameters->requiredKeys()->contains($key)
+        );
+
+        array_walk($missing, function (&$item) {
+            $parameter = $this->parameters->get($item);
+            $item = $parameter->type()->typeHinting()
+                . " {$item}";
+        });
+
+        if ($missing !== []) {
+            throw new BadMethodCallException(
+                (string) message(
+                    'Missing argument(s) [`%arguments%`] for `%action%`',
+                    arguments: implode(', ', $missing),
+                    action: $this->action::class
+                )
+            );
+        }
+
         if ($countRequired > $countProvided
-            || $countRequired !== $countProvided
+            || $countRequired !== $countIntersect
+            || $countProvided > $countTotal
         ) {
-            $parameters = implode(', ', $this->parameters->requiredKeys()->toArray());
+            $parameters = implode(', ', $requiredKeys);
             $parameters = $parameters === '' ? '' : "[{$parameters}]";
 
             throw new ArgumentCountError(

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -47,11 +47,13 @@ final class JobTest extends TestCase
 
     public function testArgumentCountErrorRequired(): void
     {
-        $this->expectException(ArgumentCountError::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage(
-            '`'
+            'Missing argument(s) [`'
+            . 'string'
+            . ' foo`] for `'
             . TestActionParam::class
-            . '::run` requires 1 argument(s) `[foo]`'
+            . '`'
         );
         $action = new TestActionParam();
         new Job($action);

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Chevere\Tests;
 
 use ArgumentCountError;
-use BadMethodCallException;
 use Chevere\Tests\src\TestActionNoParams;
 use Chevere\Tests\src\TestActionNoParamsIntResponse;
 use Chevere\Tests\src\TestActionObjectConflict;
@@ -47,7 +46,7 @@ final class JobTest extends TestCase
 
     public function testArgumentCountErrorRequired(): void
     {
-        $this->expectException(BadMethodCallException::class);
+        $this->expectException(ArgumentCountError::class);
         $this->expectExceptionMessage(
             'Missing argument(s) [`'
             . 'string'
@@ -189,7 +188,7 @@ final class JobTest extends TestCase
 
     public function testWithMissingArgument(): void
     {
-        $this->expectException(BadMethodCallException::class);
+        $this->expectException(ArgumentCountError::class);
         $this->expectExceptionMessage(
             'Missing argument(s) [`'
             . stdClass::class


### PR DESCRIPTION
Updated Job::assertArgumentsCount() to support distinction between required and optional parameters. Updated JobTest::testArgumentCountErrorRequired() to match, supporting missing parameter vs count() only